### PR TITLE
Fix warning "function create_function is deprecated"

### DIFF
--- a/metamedia.php
+++ b/metamedia.php
@@ -97,5 +97,9 @@ class MetaMedia {
 
 };
 
-add_action( 'plugins_loaded', create_function( '', 'global $MetaMedia; $MetaMedia = new MetaMedia();' ) );
-?>
+add_action(
+	'plugins_loaded', function () {
+		global $MetaMedia;
+		$MetaMedia = new MetaMedia();
+	}
+);


### PR DESCRIPTION
# Main description
The function create_function is deprecated.

# Solution description
The function create_function was replaced by an anonymous function.